### PR TITLE
v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-virgil-crypto",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "React Native Bridge for Virgil Crypto Library",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
### What's new

* Group encryption primitives (meant as low-level building blocks for implementing group chats in E3kit).
* Autolinking on iOS with React Native > 0.61.0
* Unified error names between React Native and JS

### BREAKING CHANGES

* If you're on React Native v0.60.x, you'll need to explicitly disable autolinking of `react-native-virgil-crypto`. To do that, you'll need to update your `react-native.config.js`'s `dependencies` entry to look like this (create this file in the root of your project if you don't have it):
    ```javascript
    // react-native.config.js
    module.exports = {
      dependencies: {
        'react-native-virgil-crypto': {
          platforms: {
            ios: null // disable iOS platform, other platforms will still autolink if provided
          }
        }
      }
    };
    ```

* If you relied on errors thrown by this library to have the `name` property equal to `"RNVirgilCryptoError"`, you'll need to update your code because this is no longer the case. You can do `instanceof` check instead. So, if you had code like this:

    ```javascript
    import { virgilCrypto } from 'react-native-virgil-crypto';

    try {
        const decryptedMessage = virgilCrypto.decrypt(encryptedMessage);
    } catch (err) {
        if (err.name === 'RNVirgilCryptoError') {
            // decryption failed
        }
    }
    ```

    It can be re-written like this:

    ```diff
    -import { virgilCrypto } from 'react-native-virgil-crypto';
    +import { virgilCrypto, RNVirgilCryptoError } from 'react-native-virgil-crypto';

     try {
            const decryptedMessage = virgilCrypto.decrypt(encryptedMessage);
     } catch (err) {
    -       if (err.name === 'RNVirgilCryptoError') {
    +       if (err instanceof RNVirgilCryptoError) {
                    // decryption failed
            }
     }
    ```
