### PR TITLE
Renamed deprecated "classifier" to "archiveClassifier"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,12 +105,12 @@ afterEvaluate { project ->
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from androidJavadoc.destinationDir
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }


### PR DESCRIPTION
In the latest version of Expo, gradle needs "classifier" to be changed to "archiveClassifier" in order to successfully build.  Let me know if you need any more info.