### PR TITLE
Update react-native peerDependency to allow newer versions of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
+    "react": ">=18.2.0",
     "react-native": ">=0.74.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.74.1"
+    "react-native": ">=0.74.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
Update peer dependency to allow react-native >=0.74.1
